### PR TITLE
Fixing compilation errors with newer gcc versions.

### DIFF
--- a/analysis/SatsumaSynteny2.cc
+++ b/analysis/SatsumaSynteny2.cc
@@ -7,6 +7,7 @@
 
 #include <string.h>
 #include <unistd.h>
+#include <memory>
 #include "../base/CommandLineParser.h"
 #include "SequenceMatch.h"
 #include "GridSearch.h"


### PR DESCRIPTION
Newer gcc versions error out on the std::shared_ptr references in analysis/SatsumaSynteny2.cc without this header.
```
/home/snehring/projects/satsuma2/analysis/SatsumaSynteny2.cc:154:26: error: ‘shared_ptr’ is not a member of ‘std’
  154 |       match_blocks= std::shared_ptr<std::vector<match_segments>>(new vector<match_segments>());
      |                          ^~~~~~~~~~
/home/snehring/projects/satsuma2/analysis/SatsumaSynteny2.cc:154:26: note: ‘std::shared_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
```